### PR TITLE
Ensure that module the descriptor is properly indexed and versioned

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,37 @@
                 </executions>
             </plugin>
             <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>${java.home}/bin/jar</executable>
+                            <arguments>
+                                <argument>--update</argument>
+                                <argument>--file</argument>
+                                <argument>${project.build.directory}/${project.artifactId}-${project.version}.jar</argument>
+                                <argument>--module-version</argument>
+                                <argument>${project.version}</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
                 <version>3.3.1</version>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,10 +1,10 @@
 module io.github.dmlloyd.classfile {
     exports io.github.dmlloyd.classfile;
     exports io.github.dmlloyd.classfile.attribute;
+    exports io.github.dmlloyd.classfile.components;
+    exports io.github.dmlloyd.classfile.constantpool;
     exports io.github.dmlloyd.classfile.extras;
     exports io.github.dmlloyd.classfile.extras.constant;
     exports io.github.dmlloyd.classfile.extras.reflect;
-    exports io.github.dmlloyd.classfile.components;
-    exports io.github.dmlloyd.classfile.constantpool;
     exports io.github.dmlloyd.classfile.instruction;
 }


### PR DESCRIPTION
This amounts to executing the `jar` tool to update the module descriptor information.